### PR TITLE
PoC: holdable Puppet package provider

### DIFF
--- a/lib/puppet/provider/dpkg_hold/dpkg.rb
+++ b/lib/puppet/provider/dpkg_hold/dpkg.rb
@@ -1,0 +1,77 @@
+Puppet::Type.type(:dpkg_hold).provide(:dpkg) do
+  self::DPKG_QUERY_FORMAT_STRING = %Q{'${Status} ${Package}\\n'}
+  self::FIELDS_REGEX = %r{^(\S+) +(\S+) +(\S+) (\S+)$}
+  self::FIELDS= [:desired, :error, :status, :name]
+
+  commands :dpkgquery => "/usr/bin/dpkg-query"
+  commands :dpkg => "/usr/bin/dpkg"
+
+  # Performs a dpkgquery call with a pipe so that output can be processed
+  # inline in a passed block.
+  # @param args [Array<String>] any command line arguments to be appended to the command
+  # @param block expected to be passed on to execpipe
+  # @return whatever the block returns
+  # @see Puppet::Util::Execution.execpipe
+  # @api private
+  def self.dpkgquery_piped(*args, &block)
+    cmd = args.unshift(command(:dpkgquery))
+    Puppet::Util::Execution.execpipe(cmd, &block)
+  end
+
+  def self.instances
+    packages = []
+
+    # list out all of the packages
+    dpkgquery_piped('-W', '--showformat', self::DPKG_QUERY_FORMAT_STRING) do |pipe|
+      # now turn each returned line into a package object
+      pipe.each_line do |line|
+        if hash = parse_line(line)
+          packages << new(hash)
+        end
+      end
+    end
+
+    packages
+  end
+
+  # @param line [String] one line of dpkg-query output
+  # @return [Hash,nil] a hash of FIELDS or nil if we failed to match
+  # @api private
+  def self.parse_line(line)
+    hash = nil
+
+    if match = self::FIELDS_REGEX.match(line)
+      hash = {}
+
+      self::FIELDS.zip(match.captures) do |field,value|
+        hash[field] = value
+      end
+
+      hash[:provider] = self.name
+    else 
+      Puppet.debug("Failed to match dpkg-query line #{line.inspect}")
+    end
+
+    return hash
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Tempfile.open('puppet_dpkg_set_selection') do |tmpfile|
+      tmpfile.write("#{@resource[:name]} hold\n")
+      tmpfile.flush
+      execute([:dpkg, "--set-selections"], :failonfail => false, :combine => false, :stdinfile => tmpfile.path.to_s)
+    end
+  end
+
+  def destroy
+    Tempfile.open('puppet_dpkg_set_selection') do |tmpfile|
+      tmpfile.write("#{@resource[:name]} install\n")
+      tmpfile.flush
+      execute([:dpkg, "--set-selections"], :failonfail => false, :combine => false, :stdinfile => tmpfile.path.to_s)
+    end
+  end
+end

--- a/lib/puppet/provider/package/held_apt.rb
+++ b/lib/puppet/provider/package/held_apt.rb
@@ -1,5 +1,6 @@
 Puppet::Type.type(:package).provide :held_apt, :parent => :apt, :source => :dpkg do
   defaultfor :osfamily => :debian
+  has_feature :versionable, :install_options
 
   def self.parse_line(line)
     hash = nil

--- a/lib/puppet/provider/package/held_apt.rb
+++ b/lib/puppet/provider/package/held_apt.rb
@@ -1,0 +1,27 @@
+Puppet::Type.type(:package).provide :held_apt, :parent => :apt, :source => :dpkg do
+  defaultfor :osfamily => :debian
+
+  def self.parse_line(line)
+    hash = nil
+
+    if match = self::FIELDS_REGEX.match(line)
+      hash = {}
+
+      self::FIELDS.zip(match.captures) do |field,value|
+        hash[field] = value
+      end
+
+      hash[:provider] = self.name
+
+      if hash[:status] == 'not-installed'
+        hash[:ensure] = :purged
+      elsif ['config-files', 'half-installed', 'unpacked', 'half-configured'].include?(hash[:status])
+        hash[:ensure] = :absent
+      end
+    else
+      Puppet.debug("Failed to match dpkg-query line #{line.inspect}")
+    end
+
+    return hash
+  end
+end

--- a/lib/puppet/type/aptly_purge.rb
+++ b/lib/puppet/type/aptly_purge.rb
@@ -121,34 +121,42 @@ EOS
   end
 
   def mark_manual(packages, outfile)
-    Open3.pipeline_w('xargs apt-mark manual', :out=>outfile) do |i, ts|
-      i.puts(packages)
-      i.close
-      ts[0].value.success? or raise "Failed to apt-mark packages"
+    unless packages.empty?
+      Open3.pipeline_w('xargs apt-mark manual', :out=>outfile) do |i, ts|
+        i.puts(packages)
+        i.close
+        ts[0].value.success? or raise "Failed to apt-mark packages"
+      end
     end
   end
 
   def mark_auto(packages, outfile)
-    Open3.pipeline_w('xargs apt-mark auto', :out=>outfile) do |i, ts|
-      i.puts(packages)
-      i.close
-      ts[0].value.success? or raise "Failed to apt-mark packages"
+    unless packages.empty?
+      Open3.pipeline_w('xargs apt-mark auto', :out=>outfile) do |i, ts|
+        i.puts(packages)
+        i.close
+        ts[0].value.success? or raise "Failed to apt-mark packages"
+      end
     end
   end
 
   def hold(packages, outfile)
-    Open3.pipeline_w('xargs apt-mark hold', :out=>outfile) do |i, ts|
-      i.puts(packages)
-      i.close
-      ts[0].value.success? or raise "Failed to apt-mark packages"
+    unless packages.empty?
+      Open3.pipeline_w('xargs apt-mark hold', :out=>outfile) do |i, ts|
+        i.puts(packages)
+        i.close
+        ts[0].value.success? or raise "Failed to apt-mark packages"
+      end
     end
   end
 
   def unhold(packages, outfile)
-    Open3.pipeline_w('xargs apt-mark unhold', :out=>outfile) do |i, ts|
-      i.puts(packages)
-      i.close
-      ts[0].value.success? or raise "Failed to apt-mark packages"
+    unless packages.empty?
+      Open3.pipeline_w('xargs apt-mark unhold', :out=>outfile) do |i, ts|
+        i.puts(packages)
+        i.close
+        ts[0].value.success? or raise "Failed to apt-mark packages"
+      end
     end
   end
 

--- a/lib/puppet/type/aptly_purge.rb
+++ b/lib/puppet/type/aptly_purge.rb
@@ -58,9 +58,10 @@ EOS
     # Then dpkg will remove both A and B.  This is bad!
     mark_manual managed_package_names, outfile
 
-    # It would be excellent to set 'apt-mark hold' on all managed packages
-    # here, but it turns out this doesn't interact well with dpkg based
-    # package providers.
+    #TODO: only hold packages that aren't ensure=>latest.
+    #TODO: if you're really going to do it right, set this at the package
+    # provider level. There's no reason holding needs to go within the
+    # generate() hackery.
     hold managed_package_names, outfile
 
     mark_auto unmanaged_package_names, outfile

--- a/lib/puppet/type/aptly_purge.rb
+++ b/lib/puppet/type/aptly_purge.rb
@@ -61,6 +61,7 @@ EOS
     # It would be excellent to set 'apt-mark hold' on all managed packages
     # here, but it turns out this doesn't interact well with dpkg based
     # package providers.
+    hold managed_package_names, outfile
 
     mark_auto unmanaged_package_names, outfile
 
@@ -106,6 +107,14 @@ EOS
 
   def mark_auto(packages, outfile)
     Open3.pipeline_w('xargs apt-mark auto', :out=>outfile) do |i, ts|
+      i.puts(packages)
+      i.close
+      ts[0].value.success? or raise "Failed to apt-mark packages"
+    end
+  end
+
+  def hold(packages, outfile)
+    Open3.pipeline_w('xargs apt-mark hold', :out=>outfile) do |i, ts|
       i.puts(packages)
       i.close
       ts[0].value.success? or raise "Failed to apt-mark packages"

--- a/lib/puppet/type/dpkg_hold.rb
+++ b/lib/puppet/type/dpkg_hold.rb
@@ -1,0 +1,9 @@
+Puppet::Type.newtype(:dpkg_hold) do
+  @doc = "Mark a dpkg package as held"
+
+  ensurable
+
+  autorequire(:package) do
+    self[:title]
+  end
+end

--- a/lib/puppet/type/dpkg_hold.rb
+++ b/lib/puppet/type/dpkg_hold.rb
@@ -3,7 +3,11 @@ Puppet::Type.newtype(:dpkg_hold) do
 
   ensurable
 
+  newparam(:name) do
+     desc "The name of the package."
+  end
+
   autorequire(:package) do
-    self[:title]
+    self[:name]
   end
 end


### PR DESCRIPTION
@kmosher, @solarkennedy: I wanted to draw your attention to this method.  It's not "there" yet, but it appears to work in initial testing.

The provider removes a single line from the default Puppet dpkg provider, causing it to not freak out when a package is in the held state.  The aptly_purge type then sets all packages to held.  The remainder of packages (the unheld ones) should be possible to safely dist-upgrade.
