### PR TITLE
Fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ group :development, :unit_tests do
 end
 
 group :system_tests do
-  #gem 'beaker',              :require => false
-  gem 'beaker', github: 'puppetlabs/beaker', branch: 'master'
-  gem 'beaker-rspec',        :require => false
-  gem 'beaker_spec_helper',  :require => false
-  gem 'serverspec',          :require => false
+  gem 'beaker',                       :require => false
+  gem 'beaker-rspec',                 :require => false
+  gem 'beaker_spec_helper',           :require => false
+  gem 'beaker-puppet_install_helper', :require => false
+  gem 'serverspec',                   :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ Puppet `ensure=>absent` resources.
 
 ## Usage
 
-Usage is like so:
+Usage is as follows. Unless `APT::Get::Purge` is set to `true`, it'll take two Puppet
+runs for `aptly_purge` to know which packages can be purged.
 
 ~~~~
+include package_purging::config
 aptly_purge { 'packages': }
 ~~~~
 
 To see what would be removed:
 
 ~~~~
+include package_purging::config
 aptly_purge { 'packages':
   noop => true,
 }

--- a/lib/puppet/type/aptly_purge.rb
+++ b/lib/puppet/type/aptly_purge.rb
@@ -54,7 +54,9 @@ EOD
     end
 
     managed_package_names = managed_packages.map(&:name)
+    Puppet.debug "managed_package_names: #{managed_package_names}"
     unmanaged_package_names = unmanaged_packages.map(&:name)
+    Puppet.debug "unmanaged_package_names: #{unmanaged_package_names}"
 
     holds = []
 
@@ -93,6 +95,7 @@ EOS
     mark_auto unmanaged_package_names, outfile
 
     apt_would_purge = get_purges()
+    Puppet.debug "apt_would_purge: #{apt_would_purge.to_a}"
 
     removes = unmanaged_packages.select do |r|
       # This is the crux.  We intersect the list of packages Puppet isn't

--- a/lib/puppet/type/aptly_purge.rb
+++ b/lib/puppet/type/aptly_purge.rb
@@ -1,5 +1,7 @@
 require 'set'
 require 'open3'
+require 'puppet/parameter/boolean'
+
 
 Puppet::Type.newtype(:aptly_purge) do
   @doc = <<-EOD

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,27 @@
+# Class: package_purging::config
+# ===========================
+#
+# Manages APT config settings
+#
+# Parameters
+# ----------
+#
+# * `apt_conf_d_filename`
+# Which filename, under /etc/apt.conf.d/, to store the settings in.
+# If `undef`, the file won't be created.
+#
+class package_purging::config(
+  $apt_conf_d_filename = '90always_purge',
+) {
+
+  if $apt_conf_d_filename {
+    file {"/etc/apt/apt.conf.d/${apt_conf_d_filename}":
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => "APT::Get::Purge \"true\";\n",
+    }
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,5 @@
+# Class: package_purging
+# ===========================
+#
+class package_purging {
+}

--- a/spec/acceptance/purges_safely_spec.rb
+++ b/spec/acceptance/purges_safely_spec.rb
@@ -2,16 +2,34 @@ require 'spec_helper_acceptance'
 
 describe 'package_purging_with_apt' do
 
-  context "With existing packages on the system" do
+  context 'aptly_purge with dangling dependencies (packages) on the system' do
     before :all do
+      hosts.each do |host|
+        # dictd is a dependency of dict-jargon, it's not currently installed
+        expect(check_for_package host, 'dictd').to be false
+        # install dict-jargon outside of Puppet
+        install_package host, 'dict-jargon'
+        # uninstalling dict-jargon causes its dependencies to be left behind
+        host.uninstall_package 'dict-jargon'
+        # in fact, dictd is still around
+        expect(check_for_package host, 'dictd').to be true
+      end
+    end
+
+    it 'should run without errors' do
       pp = <<-EOS
         package { 'ubuntu-minimal': }
         aptly_purge { 'packages': }
       EOS
-      apply_manifest(pp, :expect_changes => true)
+      apply_manifest(pp, :debug => true)
+      expect(@result.exit_code).to eq 0
     end
 
-    describe package('openssh-server') do
+    describe package('dict-jargon') do
+      it { should_not be_installed }
+    end
+
+    describe package('dictd') do
       it { should_not be_installed }
     end
   end

--- a/spec/acceptance/purges_safely_spec.rb
+++ b/spec/acceptance/purges_safely_spec.rb
@@ -1,39 +1,82 @@
 require 'spec_helper_acceptance'
 
 describe 'package_purging_with_apt' do
+  let :package_purging_manifest do
+    <<-EOS
+      package { 'ubuntu-minimal': }
+      package { 'puppetlabs-release-pc1': }
+      package { 'puppet-agent': }
+      package { 'fortunes': }
+      include package_purging::config
+      aptly_purge { 'packages': }
+    EOS
+  end
 
-  context 'aptly_purge with dangling dependencies (packages) on the system' do
-    before :all do
-      hosts.each do |host|
-        # dictd is a dependency of dict-jargon, it's not currently installed
-        expect(check_for_package host, 'dictd').to be false
-        # install dict-jargon outside of Puppet
-        install_package host, 'dict-jargon'
-        # uninstalling dict-jargon causes its dependencies to be left behind
-        host.uninstall_package 'dict-jargon'
-        # in fact, dictd is still around
-        expect(check_for_package host, 'dictd').to be true
+  before :all do
+    hosts.each do |host|
+      # install dict-jargon outside of Puppet
+      install_package host, 'dict-jargon'
+      # dictd gets automatically installed as a dependency of dict-jargon
+      expect(check_for_package host, 'dictd').to be true
+      # Normally, "apt-get autoremove" would only remove dictd if dict-jargon was manually
+      # uninstalled, because in that case dictd would become a "dangling dependency".
+      # aptly_purge marks any unmanaged package (any package that's been installed outside
+      # of Puppet) as automatically installed. This is counter-intuitive: because of aptly_purge
+      # manually installed packages are passed to "apt-mark auto" and will have "Auto-Installed: 1"
+      # in /var/lib/apt/extended_states .
+      # Any "Auto-Installed: 1" package shows up in the output of "apt-get -s autoremove" and,
+      # unless included in the Puppet catalog, will be purged by aptly_purge.
 
-        # enable purge by default
-        create_remote_file host, '/etc/apt/apt.conf.d/99always-purge', "APT::Get::Purge \"true\";\n";
-      end
+      # fortunes is also manually installed but, as opposed to dict-jargon, a corresponding package
+      # resource is declared in the manifest. Therefore, aptly_purge will not uninstall fortunes
+      # and its tree of dependencies.
+      install_package host, 'fortunes'
+
+      # regardless of parse order, aptly_purge will be a noop until
+      # the APT::Get::Purge config option is set (which happens on the first puppet run)
+      on host, 'puppet config set ordering random'
+      on host, 'puppet config print ordering | grep -q random'
+      expect(@result.exit_code).to eq 0
+    end
+  end
+
+  describe package('ubuntu-minimal') do
+    it { should be_installed }
+  end
+
+  context 'aptly_purge with unmanaged packages on the system, first puppet run' do
+    it 'should not remove any packages' do
+      # aptly_purge generates the list of packages to purge at "parse time"
+      # before/require ordering constraints don't work on it
+      apply_manifest(package_purging_manifest)
+      expect(@result.exit_code).to eq 0
     end
 
-    it 'should run without errors' do
-      pp = <<-EOS
-        package { 'ubuntu-minimal': }
-        aptly_purge { 'packages': }
-      EOS
-      apply_manifest(pp, :debug => true)
+    describe package('dict-jargon') do
+      it { should be_installed }
+    end
+    describe package('dictd') do
+      it { should be_installed }
+    end
+  end
+
+  context 'aptly_purge with unmanaged packages on the system, second puppet run' do
+    it 'should remove unmanaged packages' do
+      apply_manifest(package_purging_manifest, :debug => true)
       expect(@result.exit_code).to eq 0
     end
 
     describe package('dict-jargon') do
       it { should_not be_installed }
     end
-
     describe package('dictd') do
       it { should_not be_installed }
+    end
+    describe package('fortunes') do
+      it { should be_installed }
+    end
+    describe package('fortunes-min') do  # a dependency of fortunes
+      it { should be_installed }
     end
   end
 

--- a/spec/acceptance/purges_safely_spec.rb
+++ b/spec/acceptance/purges_safely_spec.rb
@@ -13,6 +13,9 @@ describe 'package_purging_with_apt' do
         host.uninstall_package 'dict-jargon'
         # in fact, dictd is still around
         expect(check_for_package host, 'dictd').to be true
+
+        # enable purge by default
+        create_remote_file host, '/etc/apt/apt.conf.d/99always-purge', "APT::Get::Purge \"true\";\n";
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 ENV['STRICT_VARIABLES']='yes'
 require 'puppetlabs_spec_helper/module_spec_helper'
-require 'hiera-puppet-helper'
-require 'rspec-hiera-hotfix.rb'
+
+RSpec.configure do |config|
+    config.raise_errors_for_deprecations!
+    config.mock_with :rspec do |mocks|
+        mocks.verify_partial_doubles = true
+    end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,43 +1,14 @@
-require 'beaker-rspec'
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
 
-def ldapsearch(cmd, exit_codes = [0,1], &block)
-  shell("ldapsearch #{cmd}", :acceptable_exit_codes => exit_codes, &block)
-end
-
-hosts.each do |host|
-  # Install Puppet
-  install_puppet()
-  # Install ruby-augeas
-  case fact('osfamily')
-  when 'Debian'
-    # Fix for beaker on Docker
-    on host, 'rm /usr/sbin/policy-rc.d || true'
-    if fact('operatingsystem') == 'Debian' and fact('operatingsystemmajrelease').to_i < 7
-      on host, 'echo deb http://httpredir.debian.org/debian-backports squeeze-backports main >> /etc/apt/sources.list'
-      on host, 'apt-get update'
-      on host, 'apt-get -y -t squeeze-backports install libaugeas0 augeas-lenses'
-    end
-    install_package host, 'libaugeas-ruby'
-  when 'RedHat'
-    on host, 'setenforce 0' if fact('selinux') == 'true'
-    install_package host, 'make'
-    install_package host, 'gcc'
-    install_package host, 'ruby-devel'
-    install_package host, 'augeas-devel'
-    install_package host, 'initscripts' # FIXME: openldap_database's olc provider's create method should call systemctl when using systemd
-    on host, 'gem install ruby-augeas --no-ri --no-rdoc'
-  else
-    puts 'Sorry, this osfamily is not supported.'
-    exit
-  end
-  on host, 'puppet cert generate $(facter fqdn)'
-  install_package host, 'net-tools'
-end
+run_puppet_install_helper
 
 RSpec.configure do |c|
+  c.filter_run :focus => true
+  c.run_all_when_everything_filtered = true
   # Project root
-  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-  module_name = module_root.split('-').last
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
   # Readable test descriptions
   c.formatter = :documentation
@@ -45,56 +16,8 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module and dependencies
-    puppet_module_install(:source => module_root, :module_name => module_name)
-
-    # Set up Certificates
-    pp = <<-EOS
-      $ssldir = '/var/lib/puppet/ssl'
-      file { '/etc/ldap':
-        ensure => directory,
-      }
-      file { '/etc/ldap/ssl':
-        ensure => directory,
-      }
-      if $::osfamily == 'Debian' {
-        # OpenLDAP is linked towards GnuTLS on Debian so we have to convert the key
-        package { 'gnutls-bin':
-          ensure => present,
-        }
-        ->
-        exec { "certtool -k < ${ssldir}/private_keys/${::fqdn}.pem > /etc/ldap/ssl/${::fqdn}.key":
-          creates => "/etc/ldap/ssl/${::fqdn}.key",
-          path    => $::path,
-          require => File['/etc/ldap/ssl'],
-          before  => File["/etc/ldap/ssl/${::fqdn}.key"],
-        }
-      } else {
-        File <| title == "/etc/ldap/ssl/${::fqdn}.key" |> {
-          source => "${ssldir}/private_keys/${::fqdn}.pem",
-        }
-      }
-      file { "/etc/ldap/ssl/${::fqdn}.key":
-        ensure  => file,
-        mode    => '0644',
-      }
-      file { "/etc/ldap/ssl/${::fqdn}.crt":
-        ensure  => file,
-        mode    => '0644',
-        source  => "${ssldir}/certs/${::fqdn}.pem",
-      }
-      file { '/etc/ldap/ssl/ca.pem':
-        ensure  => file,
-        mode    => '0644',
-        source  => "${ssldir}/certs/ca.pem",
-      }
-    EOS
-
-    apply_manifest_on(hosts, pp, :catch_failures => false)
-
     hosts.each do |host|
-      on host, puppet('module','install','herculesteam-augeasproviders_core'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module','install','herculesteam-augeasproviders_shellvar'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+      copy_root_module_to(host, :source => proj_root, :module_name => 'package_purging')
     end
   end
 end

--- a/spec/unit/puppet/type/aptly_purge_spec.rb
+++ b/spec/unit/puppet/type/aptly_purge_spec.rb
@@ -1,23 +1,23 @@
 require 'puppet'
+require 'spec_helper'
 
 describe Puppet::Type.type(:aptly_purge) do
   before :each do
     @catalog = Puppet::Resource::Catalog.new
     @package = Puppet::Type.type(:package)
 
-    @purge = Puppet::Type.type(:aptly_purge).new(:title => 'packages')
+    @purge = Puppet::Type.type(:aptly_purge).new(:title => 'packages', :debug => true)
     @catalog.add_resource @purge
 
     @existing_package = @package.new(:name => 'existing_package')
-    @package.stub(:instances) { [@existing_package] }
+    allow(@package).to receive(:instances).and_return([@existing_package])
 
-    @purge.stub(:mark_manual)
-    @purge.stub(:mark_auto)
-    @purge.stub(:unhold)
+    allow(@purge).to receive(:mark_manual)
+    allow(@purge).to receive(:mark_auto)
   end
 
   it "correctly reads from the autoremover" do
-    @purge.stub(:get_purges) { ['existing_package'] }
+    allow(@purge).to receive(:get_purges).and_return(['existing_package'])
     expect(@purge.generate).to eql([@existing_package])
   end
 
@@ -33,10 +33,10 @@ describe Puppet::Type.type(:aptly_purge) do
   end
 
   it "correctly marks packages in the catalog as manually installed" do
-    @purge.stub(:all_packages_synced) { true }
+    allow(@purge).to receive(:all_packages_synced).and_return(true)
     @test_package = @package.new(:name => 'test_package')
     @catalog.add_resource @test_package
-    @package.stub(:instances) { [@existing_package, @test_package] }
+    allow(@package).to receive(:instances).and_return([@existing_package, @test_package])
     expect(@purge).to receive(:mark_manual).with(['test_package'], '/dev/stdout')
     @purge.generate
   end


### PR DESCRIPTION
- fix both spec and acceptance tests
- add basic debugging output

Notes:

- Beaker doesn't work on the devboxes because `safer-docker` [gets in the way](https://github.com/puppetlabs/beaker/blob/3.8.0/lib/beaker/hypervisor/docker.rb#L110). As a workaround, I've added an "` && !ENV['DOCKER_HOST'].match(/safer_docker/)`" to the end of that line.
- In the output of `apt-get -s autoremove`, the code looks for lines starting with `Purg`. Unless the `--purge` CLI option or the `APT::Get::Purge` config option are used, dangling dependencies will be flagged with `Remv` instead. The code will never notice/purge them.

        root@de4b5b779e37:/# apt-get -s autoremove | grep dictd
          dict dictd dictzip libfile-copy-recursive-perl libmaa3 librecode0 m4 recode
        Remv dictd [1.12.1+dfsg-2]

    Any thoughts about what we should be doing here? Grep for either `Purg` or `Remv`? Tell the user that apt needs to be configured in a certain way for the module to work?

Tests output: https://i.fluffy.cc/FmGjt7rr41mddfQVR8X2RQ9KFNgkqTbM.html

Internal ticket: OPSIMP-632 _Test and roll out puppet dpkg holding strategy_.

/cc @solarkennedy, @oholiab
